### PR TITLE
Dev branch 2

### DIFF
--- a/symlark/symlark.py
+++ b/symlark/symlark.py
@@ -96,7 +96,7 @@ def identify_dirs(d: str, pattern: str=r"v\d{8}") -> list:
 
 
 def find_versions(dr):
-    return sorted([os.path.basename(v) for v in glob.glob(f"{dr}/v20??????")])
+    return sorted([os.path.basename(v) for v in glob.glob(f"{dr}/v????????")])
 
 
 class VersionDir:
@@ -181,7 +181,11 @@ def main(bd1: str, bd2: str) -> None:
 
             # If the GWS version is newer: then maybe this is ready for ingestion, or needs attention
             else:
-                logger.warning(f"GWS version is newer than archive dir: {gv_path} newer than {av_path}")
-                logger.warning(f"    And latest link points to {Path(gws_dir + '/latest').readlink()}")
+                logger.warning(f"GWS version is newer than archive dir: {gv_path} newer than {arc_dir.dr}/{arc_dir.latest}")
+                latest_link=Path(gws_dir.dr + '/latest')
+                if os.path.exists(latest_link):
+                    logger.warning(f"    And latest link points to {latest_link.readlink()}")
+                else:
+                    logger.warning(f"    No latest link exists for {gv_path}")
 
 

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -50,15 +50,12 @@ def setup_container_dir(basedir, versions, latest=None, arc_links=None):
     
     if arc_links:
         cwd = os.getcwd()
-        print(cwd)
         if not basedir in cwd:
             # If not already in basedir, change to basedir (this is the case if no 'latest' link is specificed)
             os.chdir(basedir)
             
         for arc_link, av_dir in arc_links.items():
             target = f"{TEST_GWS_TO_ARC}/{av_dir}"
-            print(target)
-            print(arc_link)
             os.symlink(target, arc_link) 
 
     os.chdir(TOP_DIR)
@@ -132,8 +129,6 @@ def test_old_gws_version_needs_deleting_and_symlink(caplog):
     assert caplog.records[3].message == f"Symlinking {gv_dir} to: {av_dir}"
     assert caplog.records[4].message == f"[ACTION] Deleted old version in GWS: {gv_dir}"
     
-    #import pdb ; pdb.set_trace()
-
     
 def test_newer_gws_than_archive(caplog):
     # Create an archive directory with one version v20220203

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -51,6 +51,8 @@ def setup_container_dir(basedir, versions, latest=None, arc_links=None):
     if arc_links:
         for arc_link, av_dir in arc_links.items():
             target = f"{TEST_GWS_TO_ARC}/{av_dir}"
+            print(target)
+            print(arc_link)
             os.symlink(target, arc_link) 
 
     os.chdir(TOP_DIR)
@@ -123,3 +125,15 @@ def test_old_gws_version_needs_deleting_and_symlink(caplog):
     assert caplog.records[2].message == f"Deleting directory: {gv_dir}"
     assert caplog.records[3].message == f"Symlinking {gv_dir} to: {av_dir}"
     assert caplog.records[4].message == f"[ACTION] Deleted old version in GWS: {gv_dir}"
+    
+def test_newer_gws_than_archive(caplog):
+    # Create an archive directory with one version v20220203
+    setup_container_dir(TEST_ARC, ["v20220203"])
+    
+    # Create a GWS that points to archive version above
+    setup_container_dir(TEST_GWS, [], arc_links={"v20220203": "v20220203"})
+    
+    # Create a GWS called v24440404 that holds data
+    setup_container_dir(TEST_GWS, ["v24440404"])
+    
+    caplog.set_level(logging.INFO)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -49,6 +49,12 @@ def setup_container_dir(basedir, versions, latest=None, arc_links=None):
         os.symlink(latest, "latest")
     
     if arc_links:
+        cwd = os.getcwd()
+        print(cwd)
+        if not basedir in cwd:
+            # If not already in basedir, change to basedir (this is the case if no 'latest' link is specificed)
+            os.chdir(basedir)
+            
         for arc_link, av_dir in arc_links.items():
             target = f"{TEST_GWS_TO_ARC}/{av_dir}"
             print(target)
@@ -126,14 +132,21 @@ def test_old_gws_version_needs_deleting_and_symlink(caplog):
     assert caplog.records[3].message == f"Symlinking {gv_dir} to: {av_dir}"
     assert caplog.records[4].message == f"[ACTION] Deleted old version in GWS: {gv_dir}"
     
+    #import pdb ; pdb.set_trace()
+
+    
 def test_newer_gws_than_archive(caplog):
     # Create an archive directory with one version v20220203
-    setup_container_dir(TEST_ARC, ["v20220203"])
-    
-    # Create a GWS that points to archive version above
-    setup_container_dir(TEST_GWS, [], arc_links={"v20220203": "v20220203"})
+    setup_container_dir(TEST_ARC, ["v20220203"], latest="v20220203")
     
     # Create a GWS called v24440404 that holds data
-    setup_container_dir(TEST_GWS, ["v24440404"])
+    # AND    
+    # Create a GWS that points to archive version above
+    setup_container_dir(TEST_GWS, ["v24440404"], arc_links={"v20220203": "v20220203"})
     
     caplog.set_level(logging.INFO)
+    main(TEST_GWS, TEST_ARC)
+    
+    len(caplog.records)
+    
+    #import pdb ; pdb.set_trace()

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -44,16 +44,13 @@ def setup_container_dir(basedir, versions, latest=None, arc_links=None):
         check_dir(dr)
         create_files(dr)
 
+    # Change to basedir
+    os.chdir(basedir)
+
     if latest:
-        os.chdir(basedir)
         os.symlink(latest, "latest")
     
-    if arc_links:
-        cwd = os.getcwd()
-        if not basedir in cwd:
-            # If not already in basedir, change to basedir (this is the case if no 'latest' link is specificed)
-            os.chdir(basedir)
-            
+    if arc_links:    
         for arc_link, av_dir in arc_links.items():
             target = f"{TEST_GWS_TO_ARC}/{av_dir}"
             os.symlink(target, arc_link) 
@@ -142,6 +139,13 @@ def test_newer_gws_than_archive(caplog):
     caplog.set_level(logging.INFO)
     main(TEST_GWS, TEST_ARC)
     
-    len(caplog.records)
-    
+    gv_dir = f"{TEST_GWS}/v20220203"
+    av_dir = f"{TEST_ARC}/v20220203"
+
+    gv_dir2 = f"{TEST_GWS}/v24440404"
+
+    assert caplog.records[0].message == f"GWS version is newer than archive dir: {gv_dir2} newer than {av_dir}"
+    assert caplog.records[1].message == f"    No latest link exists for {gv_dir2}"
+    assert caplog.records[2].message == f"{gv_dir} correctly points to: {av_dir}"
+
     #import pdb ; pdb.set_trace()


### PR DESCRIPTION
I've added a test for the case where there's a newer GWS directory than in the archive. The test shows that symlark reports that the GWS correctly contains a symlink to the existing archive version, but I don't think that symlark highlights that a newer version exists in the GWS. Let's discuss next week!

Also, I had to add in a check for the current working directory (and change to basedir if not already there) in setup_container_dir because the 'arc_links' if statement was assuming that a change of directory to basedir had already occurred in the 'latest' if statement.