### PR TITLE
Pytest issue 10

### DIFF
--- a/symlark/symlark.py
+++ b/symlark/symlark.py
@@ -164,9 +164,12 @@ def main(bd1: str, bd2: str) -> None:
 
             # If the GWS version is older than the latest archive version: delete the GWS version
             if gws_version < arc_dir.latest:
-                delete_dir(gv_path)
-                symlink(av_path, gv_path)
-                logger.warning(f"[ACTION] Deleted old version in GWS: {gv_path}")
+                if os.path.islink(gv_path):
+                    logger.warning(f"GWS symlink already exists: {gv_path}")
+                else:
+                    delete_dir(gv_path)
+                    symlink(av_path, gv_path)
+                    logger.warning(f"[ACTION] Deleted old version in GWS: {gv_path}")
             
             # If they are the same:
             elif gws_version == arc_dir.latest:

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -212,4 +212,3 @@ def test_two_archive_versions_only_old_gws_version(caplog):
     gv_dir = f"{TEST_GWS}/v20250601"
 
     assert caplog.records[0].message == f"GWS symlink already exists: {gv_dir}"
-    import pdb ; pdb.set_trace()

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -197,3 +197,19 @@ def test_newer_gws_than_archive(caplog):
     assert caplog.records[2].message == f"{gv_dir} correctly points to: {av_dir}"
 
     #import pdb ; pdb.set_trace()
+
+def test_two_archive_versions_only_old_gws_version(caplog):
+    '''Tests for 2 version directories in the archive and 1 (old) version in the GWS.'''
+    setup_container_dir(TEST_ARC, ["v20250601", "v20260607"], latest="v20260607")
+    setup_container_dir(TEST_GWS, [], latest="v20250601",arc_links={"v20250601": "v20250601"})
+
+    caplog.set_level(logging.INFO)
+    main(TEST_GWS, TEST_ARC)
+
+    av_dir = f"{TEST_ARC}/v20250601"
+    av_dir2 = f"{TEST_ARC}/v20260607"
+
+    gv_dir = f"{TEST_GWS}/v20250601"
+
+    assert caplog.records[0].message == f"GWS symlink already exists: {gv_dir}"
+    import pdb ; pdb.set_trace()


### PR DESCRIPTION
Test written to address Issue #10 i.e. 2 archive versions and 1 (old) GWS version. In this scenario, symlark was assuming that the (already symlinked) GWS was a directory and then deleting the files in it, which actually resulted in files in the test archive being deleted. A check for whether the GWS directory is already a symlink has therefore been added to symlark and it now simply reports 'GWS symlink already exists: {gv_dir}'

Although the test now passes, symlark is actually handling this scenario incorrectly. Symlark works by iterating through the available GWS directories, assuming that there will always be a greater number of GWS version directories than archive version directories. But in this scenario, there are more archive directories than GWS directories. Symlark therefore needs to be further modified to check that the list of version directories in the GWS and the list in the archive are the same and, if not, to trigger the creation of new GWS symlinks.