### PR TITLE
Creation of 'latest' links where necessary

### DIFF
--- a/symlark/symlark.py
+++ b/symlark/symlark.py
@@ -14,7 +14,7 @@ import logging
 # Set up module-level logger
 logging.basicConfig()
 logger = logging.getLogger(__name__)
-
+logger.setLevel(logging.DEBUG)
 
 def nested_list(d: str, remove_base=False) -> list:
     r = []
@@ -68,9 +68,16 @@ def delete_dir(dr):
     os.rmdir(dr)
 
 
-def symlink(target, symlink):
+def symlink(target, symlink, relative=False):
     logger.warning(f"Symlinking {symlink} to: {target}")
-    os.symlink(target, symlink) 
+
+    if relative:
+        cwd = os.getcwd()
+        os.chdir(os.path.dirname(target))
+        os.symlink(os.path.basename(target), symlink)
+        os.chdir(cwd)
+    else:
+        os.symlink(target,symlink)
 
 
 def md5(f: str, blocksize: int=65536) -> str:
@@ -182,10 +189,10 @@ def main(base_dir1: str, base_dir2: str) -> None:
             # If the GWS version is older than the latest archive version: delete the GWS version
             if gws_version < arc_dir.latest:
                 if os.path.islink(gv_path):
-                    logger.warning(f"GWS symlink already exists: {gv_path}")
+                    os.remove(gv_path)
+                    logger.warning(f"[ACTION] Deleted symlink to older version: {gv_path}")
                 else:
                     delete_dir(gv_path)
-                    symlink(av_path, gv_path)
                     logger.warning(f"[ACTION] Deleted old version in GWS: {gv_path}")
             
             # If they are the same:
@@ -205,8 +212,10 @@ def main(base_dir1: str, base_dir2: str) -> None:
                 gws_latest_link=Path(gws_dir.dr + '/latest')
                 if os.path.exists(gws_latest_link):
                     logger.warning(f"    GWS latest link points to {gws_latest_link.readlink()}")
+                    os.remove(gws_latest_link.as_posix())
                 else:
-                    logger.warning(f"    No latest link exists for {gv_path}")                
+                    logger.warning(f"    No latest link exists for {gv_path}")
+                symlink(gv_path,'latest',relative=True)                
 
             # If the GWS version is newer: then maybe this is ready for ingestion, or needs attention
             else:


### PR DESCRIPTION
- Ensures that the GWS 'latest' link is actually updated/created rather than just having a logger warning reporting whether it exists or not.
- Updated symlink function to ensure that the 'latest' link remains a relative rather than absolute link.